### PR TITLE
Add optional dns delegator to subdomain

### DIFF
--- a/delegator.tf
+++ b/delegator.tf
@@ -1,0 +1,9 @@
+module "delegator" {
+  source = "nullstone-modules/dns-delegator/aws"
+
+  zone_id = aws_route53_zone.this.zone_id
+  name    = "dns-delegator-${local.resource_name}"
+  tags    = data.ns_workspace.this.tags
+
+  count = var.create_delegator ? 1 : 0
+}

--- a/variables.tf
+++ b/variables.tf
@@ -9,3 +9,9 @@ variable "create_cert" {
   description = "Enable this to create an SSL certificate through AWS ACM service."
   default     = true
 }
+
+variable "create_delegator" {
+  type        = bool
+  description = "Enable this to create an IAM User that only has permissions to modify the created DNS Zone."
+  default     = false
+}


### PR DESCRIPTION
This PR adds an optional `dns-delegator` IAM user.
This is necessary to manage `nullstone.app` fully within the Domains section of nullstone.