### PR TITLE
Supporting '.' as dns-name to ignore subdomain suffix

### DIFF
--- a/calculate.tf
+++ b/calculate.tf
@@ -11,7 +11,6 @@ locals {
   subdomain       = trimsuffix(local.subdomain_chunk, ".")
   fqdn            = "${local.subdomain_chunk}${local.domain_name}"
 
-  // This record is added to the domain's zone to delegate this subdomain's records
   is_passthrough = local.fqdn == local.domain_name
 
   // output locals

--- a/calculate.tf
+++ b/calculate.tf
@@ -1,0 +1,21 @@
+locals {
+  // If a user specifies '.' for dns-name,
+  //   we are going to use ${env}.${domain} as the fqdn instead of ${dns-name}.${env}.${domain}
+  dns_name_chunk = data.ns_subdomain.this.dns_name == "." ? "" : "${data.ns_subdomain.this.dns_name}."
+
+  // If user specifies var.create_vanity,
+  //   we are going to drop ${env} from the fqdn
+  env_chunk = var.create_vanity ? "" : "${data.ns_workspace.this.env_name}."
+
+  subdomain_chunk = "${local.dns_name_chunk}${local.env_chunk}"
+  subdomain       = trimsuffix(local.subdomain_chunk, ".")
+  fqdn            = "${local.subdomain_chunk}${local.domain_name}"
+
+  // This record is added to the domain's zone to delegate this subdomain's records
+  is_passthrough = local.fqdn == local.domain_name
+
+  // output locals
+  name        = ! local.is_passthrough ? aws_route53_zone.this[0].name : local.subdomain
+  zone_id     = ! local.is_passthrough ? aws_route53_zone.this[0].zone_id : local.domain_zone_id
+  nameservers = ! local.is_passthrough ? aws_route53_zone.this[0].name_servers : local.domain_nameservers
+}

--- a/cert.tf
+++ b/cert.tf
@@ -2,8 +2,8 @@ module "cert" {
   source = "nullstone-modules/sslcert/aws"
 
   domain = {
-    name    = aws_route53_zone.this.name
-    zone_id = aws_route53_zone.this.zone_id
+    name    = local.fqdn
+    zone_id = local.zone_id
   }
 
   enabled = var.create_cert

--- a/delegator.tf
+++ b/delegator.tf
@@ -1,9 +1,9 @@
 module "delegator" {
   source = "nullstone-modules/dns-delegator/aws"
 
-  zone_id = aws_route53_zone.this.zone_id
+  zone_id = aws_route53_zone.this[0].zone_id
   name    = "dns-delegator-${local.resource_name}"
   tags    = data.ns_workspace.this.tags
 
-  count = var.create_delegator ? 1 : 0
+  count = var.create_delegator && ! local.is_passthrough ? 1 : 0
 }

--- a/nullstone.tf
+++ b/nullstone.tf
@@ -13,6 +13,11 @@ data "ns_connection" "domain" {
   type = "domain/aws"
 }
 
+data "ns_subdomain" "this" {
+  stack_id = data.ns_workspace.this.stack_id
+  block_id = data.ns_workspace.this.block_id
+}
+
 // We will need to be able to support secondary providers since the root domain
 //   is typically managed in a separate account from non-production environments
 provider "aws" {
@@ -23,6 +28,7 @@ provider "aws" {
 }
 
 locals {
-  domain_name    = data.ns_connection.domain.outputs.name
-  domain_zone_id = data.ns_connection.domain.outputs.zone_id
+  domain_name        = data.ns_connection.domain.outputs.name
+  domain_zone_id     = data.ns_connection.domain.outputs.zone_id
+  domain_nameservers = data.ns_connection.domain.outputs.nameservers
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,20 +1,20 @@
 output "name" {
-  value       = data.ns_subdomain.this.dns_name
+  value       = local.name
   description = "string ||| The name that precedes the domain name for the created subdomain."
 }
 
 output "fqdn" {
-  value       = aws_route53_zone.this.name
+  value       = local.fqdn
   description = "string ||| The FQDN (fully-qualified domain name) for the created subdomain."
 }
 
 output "zone_id" {
-  value       = aws_route53_zone.this.zone_id
+  value       = local.zone_id
   description = "string ||| The zone ID of the AWS Route53 Zone for the created subdomain."
 }
 
 output "nameservers" {
-  value       = aws_route53_zone.this.name_servers
+  value       = local.nameservers
   description = "list(string) ||| The list of nameservers of the AWS Route53 Zone for the created subdomain."
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,10 @@
 variable "create_vanity" {
   type        = bool
-  description = "Enable this to create vanity subdomain instead of environmental. This is typically enabled on the production environment."
+  description = <<EOF
+Enable this to create vanity subdomain instead of environmental.
+This is typically enabled on the production environment.
+If dns-name is set to '.' and create_vanity is enabled, this will module act as a passthrough; outputs from the connected domain are used for outputs.
+EOF
   default     = false
 }
 


### PR DESCRIPTION
This PR adds support for `.` as the dns-name.
This tells the module to not prepend anything on the subdomain.

If a user specifies `dns_name='.'` and `create_vanity=false`, the fqdn will be `${env}.${domain}`.
If a user specifies `dns_name='.'` and `create_vanity=true`, no dns resources are created -- instead, the outputs are relayed from the connected domain.